### PR TITLE
fix: ensure values actually go through dump

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -34,9 +34,12 @@ end
 -- Debug
 index_table.debug = function(self, ...)
     local items = {}
-    for _, value in ipairs({ ... }) do
+    local last_index = #items
+    for index, value in ipairs({ ... }) do
         items[#items + 1] = value
-        items[#items + 1] = "\t"
+        if index < last_index then
+            items[#items + 1] = "\t"
+        end
     end
     self:none(unpack(items))
 end

--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,12 @@ end
 
 -- Debug
 index_table.debug = function(self, ...)
-    self:none(logging.format_message(self.mod, table.concat({ ... }, "\t")))
+    local items = {}
+    for _, value in ipairs({ ... }) do
+        items[#items + 1] = value
+        items[#items + 1] = "\t"
+    end
+    self:none(unpack(items))
 end
 
 -- Raise error


### PR DESCRIPTION
`table.concat` can't take `type(value) == "table"` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated internal debug logging mechanism to improve message formatting and logging process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->